### PR TITLE
Build project package to automatically resolve module imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,30 @@ Project for the Deep Learning for Life Sciences 4EU+ hackathon
 ## Prerequisites
 
 The custom `Dataset` classes in this project require that the **ProtVec** dataset [[link](http://dx.doi.org/10.7910/DVN/JMFHTN)] has been extracted into the `data` folder.
+
+## Installation 
+
+- Clone this repo:
+    ```bash
+    $ git clone https://github.com/prina404/protein-function-prediction.git 
+    $ cd protein-function-prediction/
+    ```
+
+- Initialize a python virtual environment and activate it:
+    ```bash
+    $  python3 -m venv .venv && source .venv/bin/activate
+    ```
+- Install this project as a package
+    ```bash
+    $ pip install -e .
+    ```
+Now any `*.py` module under the `src/` folder can be imported, and `src/` is automatically set as its root folder. 
+For example:
+
+```python
+# this can be a script located anywhere in this repo
+import ProteinDataset   # this imports src/ProteinDataset.py
+import utils.config     # this imports src/utils/config.py
+
+...
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "protein_function_prediction"
+version = "0.0.1"
+authors = [
+    { "name" = "Matteo Princisgh" },
+    { "name" = "Luca Arborio" },
+    { "name" = "Alice Giardina" },
+]
+description = "Protein function prediction using deep learning for the D4L Hackathon 2025 in Heidelberg"
+dependencies = [
+    "torch",
+    "pandas",
+    "matplotlib",
+    "seaborn",
+    "ipykernel",
+    "pynvml",
+    "openpyxl",
+    "scikit-learn",
+    "pyyaml",
+    "torchmetrics",
+    "tqdm",
+]
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+
+[tool.setuptools.packages.find]
+where = ["src"]


### PR DESCRIPTION
## Configure the project as a python package

This pull request introduces an installation guide in the `README.md` and adds a `pyproject.toml` file to define the python package configuration. These changes streamline the setup process for the project and make it easier to manage imports between modules in the repo.

Changes:
- Arbitrarily-nested modules can import any other module under the `src/` folder.
- Project dependencies are now inside the `pyproject.toml` file, and `requirements.txt` has been deleted


### Important
As explained in the `README.md`, the project must be installed as a package with `pip install -e .` in order to be configured correctly.

