### PR TITLE
Removed very long sequences from dataset + metrics bugfix

### DIFF
--- a/src/ProteinDataset.py
+++ b/src/ProteinDataset.py
@@ -23,6 +23,10 @@ class ProteinDataset(Dataset):
 
         # Read data from disk and initialize the label encoder
         self.data = pd.read_csv(data_file)
+        max_len = CFG['data']['max_seq_len']
+        # Remove sequences longer than max_seq_len
+        self.data = self.data[self.data["sequence"].apply(lambda x: len(x) < max_len)]
+
         self.label_encoder = LabelBinarizer().fit(self.data["label"])
 
         # Create the embedding dictionary

--- a/src/Trainer.py
+++ b/src/Trainer.py
@@ -131,8 +131,8 @@ class Trainer:
 
         progress_bar.close()
         val_loss = total_loss / len(val_data)               # avg batch loss
-        all_pred = torch.concatenate(all_pred)              # concat all tensors in a single tensor
-        all_labels = torch.concatenate(all_labels)
+        all_pred = torch.concatenate(all_pred).argmax(dim=1)              # concat all tensors in a single tensor
+        all_labels = torch.concatenate(all_labels).argmax(dim=1)
 
         # compute metrics
         metrics_result = {name: metric_fn(all_pred, all_labels) for name, metric_fn in self.metrics.items()}

--- a/src/utils/config.yaml
+++ b/src/utils/config.yaml
@@ -13,6 +13,7 @@ paths:  # paths are relative to the project's root folder
 
 data:
   batch_size: 64
+  max_seq_len: 2000
   shuffle: true
   validation_split: 0.15
   num_classes: 5


### PR DESCRIPTION
Sequences longer than 2000 residues are considered outliers and discarded from datasets. 

In total, 1523 sequences are discarded, of which only one example belongs to the `Helicase_C` class and the rest belong to the `other` class.

---

Also: Fixed bug in the trainer script which led to incorrect metrics measurements   