### PR TITLE
Added preprocessing support for n-class classification

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -17,16 +17,20 @@ class Config:
         self.data_dir = self.root_dir / self.cfg["paths"]["data_dir"]
 
         self.dataset_raw = self.root_dir / self.cfg["paths"]["dataset_raw"]
-        self.train_data = self.root_dir / self.cfg["paths"]["train_data"]
-        self.test_data = self.root_dir / self.cfg["paths"]["test_data"]
 
-        self.device = 'cuda' if torch.cuda.is_available() else 'cpu'
+        self.num_classes = self.cfg["data"]["num_classes"]
+        class_name = f"{self.num_classes}class"
+
+        self.train_data = self.root_dir / "data" / f"{class_name}/train/train_{class_name}.csv"
+        self.test_data = self.root_dir / "data" / f"{class_name}/test/test_{class_name}.csv"
+
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
 
         # TODO: add frequently used fields as class attributes
 
     def __getitem__(self, item: str):
         return self.cfg[item]
-    
+
     def save_config(self, config_path=None):
         """
         Write the current configuration to a YAML file.
@@ -36,6 +40,7 @@ class Config:
         config_path = self._path if not config_path else config_path
         with open(config_path, "w") as f:
             yaml.dump(self.cfg, f, default_flow_style=False)
+
 
 # if imported as a module, this becomes my config singleton
 CFG = Config()

--- a/src/utils/config.yaml
+++ b/src/utils/config.yaml
@@ -5,8 +5,6 @@ project:
 paths:  # paths are relative to the project's root folder
   data_dir: data/
   dataset_raw: data/dataverse_files.zip
-  train_data: data/train/train.csv
-  test_data: data/test/test.csv
   save_dir: outputs/
   log_dir: logs/
   model_checkpoint: checkpoints/


### PR DESCRIPTION
## N-class configuration extension

By setting the appropriate `num_classes` attribute in `config.yaml`, the preprocessing pipeline will be re-run to generate a new stratified dataset with the relative class number.

The new test/train splits are stored under the appropriate folder, e.g.:

```
# assuming we generated both 5-class and 100-class splits
data/
├── 5class/
│   ├── train/
│   │   └── train_5class.csv
│   └── test/
│       └── test_5class.csv
└── 100class/
    ├── train/
    │   └── train_100class.csv
    └── test/
        └── test_100class.csv
```